### PR TITLE
Fixed a couple of things for bruteforcing

### DIFF
--- a/Data/Sys/GameSettings/R32J01.ini
+++ b/Data/Sys/GameSettings/R32J01.ini
@@ -14,7 +14,7 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-$Disable Culling of Terrain Outside Camera View
+$Disable Culling Outside Camera View
 042c9b40 38600001
 042c9b44 4E800020
 

--- a/Data/Sys/GameSettings/R32J01.ini
+++ b/Data/Sys/GameSettings/R32J01.ini
@@ -14,6 +14,9 @@
 
 [ActionReplay]
 # Add action replay cheats here.
+$Disable Culling of Terrain Outside Camera View
+042c9b40 38600001
+042c9b44 4E800020
 
 [Video]
 ProjectionHack = 0

--- a/Data/Sys/GameSettings/R3IJ01.ini
+++ b/Data/Sys/GameSettings/R3IJ01.ini
@@ -14,6 +14,9 @@
 
 [ActionReplay]
 # Add action replay cheats here.
+$Disable Culling of Terrain Outside Camera View
+042c9cb8 38600001
+042c9cbc 4E800020
 
 [Video]
 ProjectionHack = 0

--- a/Data/Sys/GameSettings/R3IJ01.ini
+++ b/Data/Sys/GameSettings/R3IJ01.ini
@@ -14,7 +14,7 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-$Disable Culling of Terrain Outside Camera View
+$Disable Culling Outside Camera View
 042c9cb8 38600001
 042c9cbc 4E800020
 

--- a/Data/Sys/GameSettings/R3MP01.ini
+++ b/Data/Sys/GameSettings/R3MP01.ini
@@ -16,6 +16,18 @@ EmulationIssues = Disable PAL60 (EuRGB60) to avoid a black bar appearing.
 
 [ActionReplay]
 # Add action replay cheats here.
+$MP1 Disable Culling Outside Camera View (one at a time)
+042c8024 38600001
+042c8028 4E800020
+$MP2 Disable Culling Outside Camera View (one at a time)
+042ca730 38600001
+042ca734 4E800020
+$MP3 Disable Culling Outside Camera View (one at a time)
+04314038 38600001
+0431403C 4E800020
+$Loader Disable Culling Outside Camera View (one at a time)
+042c9950 38600001
+042c9954 4E800020
 
 [Video]
 ProjectionHack = 0

--- a/Data/Sys/GameSettings/RM3E01.ini
+++ b/Data/Sys/GameSettings/RM3E01.ini
@@ -8,7 +8,12 @@ EmulationIssues =
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
+
 [ActionReplay]
+$Disable Culling of Terrain Outside Camera View
+04316a1c 38600001
+04316a20 4E800020
+
 [Video]
 ProjectionHack = 0
 PH_SZNear = 0

--- a/Data/Sys/GameSettings/RM3E01.ini
+++ b/Data/Sys/GameSettings/RM3E01.ini
@@ -10,7 +10,7 @@ EmulationIssues =
 [OnFrame]
 
 [ActionReplay]
-$Disable Culling of Terrain Outside Camera View
+$Disable Culling Outside Camera View
 04316a1c 38600001
 04316a20 4E800020
 

--- a/Data/Sys/GameSettings/RM3P01.ini
+++ b/Data/Sys/GameSettings/RM3P01.ini
@@ -9,7 +9,12 @@ EmulationIssues =
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
+
 [ActionReplay]
+$Disable Culling of Terrain Outside Camera View
+04318170 38600001
+04318174 4E800020
+
 [Video]
 ProjectionHack = 0
 PH_SZNear = 0

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -317,6 +317,9 @@ static void FindFunctionsAfterBLR(PPCSymbolDB *func_db)
 	{
 		while (true)
 		{
+			// skip zeroes that sometimes pad function to 16 byte boundary (eg. Donkey Kong Country Returns)
+			while (Memory::Read_Instruction(location) == 0x0 && ((location & 0xf) != 0))
+				location += 4;
 			if (PPCTables::IsValidInstruction(Memory::Read_Instruction(location)))
 			{
 				//check if this function is already mapped

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -825,7 +825,7 @@ void CFrame::OnRenderWindowSizeRequest(int width, int height)
 {
 	if (!Core::IsRunning() ||
 			!SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderWindowAutoSize ||
-			RendererIsFullscreen() || m_RenderFrame->IsMaximized() || g_has_hmd)
+			RendererIsFullscreen() || m_RenderFrame->IsMaximized())
 		return;
 
 	int old_width, old_height, log_width = 0, log_height = 0;

--- a/Source/Core/VideoCommon/VR.cpp
+++ b/Source/Core/VideoCommon/VR.cpp
@@ -153,13 +153,20 @@ void InitVR()
 		}
 	}
 #endif
-	SConfig::GetInstance().m_LocalCoreStartupParameter.strFullscreenResolution = 
-		StringFromFormat("%dx%d", g_hmd_window_width, g_hmd_window_height);
-	SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowXPos = g_hmd_window_x;
-	SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowYPos = g_hmd_window_y;
-	SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowWidth = g_hmd_window_width;
-	SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowHeight = g_hmd_window_height;
-	SConfig::GetInstance().m_special_case = true;
+	if (g_has_hmd)
+	{
+		SConfig::GetInstance().m_LocalCoreStartupParameter.strFullscreenResolution =
+			StringFromFormat("%dx%d", g_hmd_window_width, g_hmd_window_height);
+		SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowXPos = g_hmd_window_x;
+		SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowYPos = g_hmd_window_y;
+		SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowWidth = g_hmd_window_width;
+		SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowHeight = g_hmd_window_height;
+		SConfig::GetInstance().m_special_case = true;
+	}
+	else
+	{
+		SConfig::GetInstance().m_special_case = false;
+	}
 }
 
 void ShutdownVR()


### PR DESCRIPTION
I fixed the zero window size you told me about.

And I fixed the symbol generation for functions that have padding to the 16 byte boundary before/after them, so when you save map files they will now be correct. This is important for games like Donkey Kong Country Returns.